### PR TITLE
Support Comma in Query Parammeter

### DIFF
--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
@@ -18,9 +18,18 @@ public class PropertyFilter {
     if (properties != null) {
       for (String property : properties) {
         property = property.trim();
-
         if (!property.isEmpty()) {
-          filter.addProperty(property);
+          if (property.contains(",")) {
+            String[] commaProperties = property.split(",");
+            for (String commaProperty : commaProperties) {
+              commaProperty = commaProperty.trim();
+              if (!commaProperty.isEmpty()) {
+                filter.addProperty(commaProperty);
+              }
+            }
+          }else {
+            filter.addProperty(property);
+          }
         }
       }
     }


### PR DESCRIPTION
Example: resource?property=field1,field2,...
