### PR TITLE
Support default filter properties

### DIFF
--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFiltering.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFiltering.java
@@ -9,5 +9,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PropertyFiltering {
   String using() default "property";
-  String[] defaultProperties() default {};
+  String[] always() default {};
 }

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFiltering.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFiltering.java
@@ -9,4 +9,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PropertyFiltering {
   String using() default "property";
+  String[] defaultProperties() default {};
 }

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
@@ -58,8 +58,8 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
                       MultivaluedMap<String, Object> httpHeaders, OutputStream os) throws IOException {
     PropertyFiltering annotation = findPropertyFiltering(annotations);
 
-    Collection<String> properties = getQueryProperties(annotation.using());
-    properties.addAll(getDefaultProperties(annotation.defaultProperties()));
+    Collection<String> properties = getProperties(annotation.using());
+    properties.addAll(Arrays.asList(annotation.defaultProperties()));
 
     PropertyFilter propertyFilter = new PropertyFilter(properties);
     if (!propertyFilter.hasFilters()) {
@@ -80,17 +80,9 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
   }
 
 
-  private Collection<String> getQueryProperties(String name) {
-    return getProperties(uriInfo.getQueryParameters().get(name));
-  }
+  private Collection<String> getProperties(String name) {
+    List<String> values = uriInfo.getQueryParameters().get(name);
 
-
-  private Collection<String> getDefaultProperties(String[] values) {
-    return getProperties(Arrays.asList(values));
-  }
-
-
-  private Collection<String> getProperties(List<String> values) {
     List<String> properties = new ArrayList<String>();
     if (values != null) {
       for (String value : values) {

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
@@ -59,7 +59,7 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
     PropertyFiltering annotation = findPropertyFiltering(annotations);
 
     Collection<String> properties = getProperties(annotation.using());
-    properties.addAll(Arrays.asList(annotation.defaultProperties()));
+    properties.addAll(Arrays.asList(annotation.always()));
 
     PropertyFilter propertyFilter = new PropertyFilter(properties);
     if (!propertyFilter.hasFilters()) {

--- a/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
@@ -89,7 +89,7 @@ public abstract class AbstractIntegrationTest {
   protected abstract String path();
   protected abstract String queryParamName();
 
-  private List<TestObject> getObjects(String... queryParams) throws IOException {
+  protected List<TestObject> getObjects(String... queryParams) throws IOException {
     String urlString = "http://localhost:" + port + "/test" + path();
     if (queryParams.length > 0) {
       urlString += "?" + queryParamName() +"=" + Strings.join(queryParams).with("&" + queryParamName() + "=");
@@ -100,28 +100,28 @@ public abstract class AbstractIntegrationTest {
     return reader.withType(listType).readValue(url.openStream());
   }
 
-  private static void assertIdPresent(List<TestObject> objects) {
+  protected static void assertIdPresent(List<TestObject> objects) {
     assertThat(objects).hasSize(10);
     for (int i = 0; i < 10; i++) {
       assertThat(objects.get(i).getId()).isEqualTo(i);
     }
   }
 
-  private static void assertNamePresent(List<TestObject> objects) {
+  protected static void assertNamePresent(List<TestObject> objects) {
     assertThat(objects).hasSize(10);
     for (int i = 0; i < 10; i++) {
       assertThat(objects.get(i).getName()).isEqualTo("Test " + i);
     }
   }
 
-  private static void assertIdNotPresent(List<TestObject> objects) {
+  protected static void assertIdNotPresent(List<TestObject> objects) {
     assertThat(objects).hasSize(10);
     for (int i = 0; i < 10; i++) {
       assertThat(objects.get(i).getId()).isNull();
     }
   }
 
-  private static void assertNameNotPresent(List<TestObject> objects) {
+  protected static void assertNameNotPresent(List<TestObject> objects) {
     assertThat(objects).hasSize(10);
     for (int i = 0; i < 10; i++) {
       assertThat(objects.get(i).getName()).isNull();

--- a/src/test/java/com/hubspot/jackson/jaxrs/AlwaysPropertiesTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/AlwaysPropertiesTest.java
@@ -5,11 +5,11 @@ import java.util.List;
 
 import static com.hubspot.jackson.jaxrs.util.TestResource.TestObject;
 
-public class DefaultPropertiesTest extends AbstractIntegrationTest {
+public class AlwaysPropertiesTest extends AbstractIntegrationTest {
 
   @Override
   protected String path() {
-    return "/default";
+    return "/always";
   }
 
   @Override

--- a/src/test/java/com/hubspot/jackson/jaxrs/DefaultPropertiesTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/DefaultPropertiesTest.java
@@ -1,0 +1,60 @@
+package com.hubspot.jackson.jaxrs;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.hubspot.jackson.jaxrs.util.TestResource.TestObject;
+
+public class DefaultPropertiesTest extends AbstractIntegrationTest {
+
+  @Override
+  protected String path() {
+    return "/default";
+  }
+
+  @Override
+  protected String queryParamName() {
+    return "property";
+  }
+
+  @Override
+  public void testNoFiltering() throws IOException {
+    List<TestObject> objects = getObjects();
+
+    assertIdPresent(objects);
+    assertNameNotPresent(objects);
+  }
+
+  @Override
+  public void testIncludeName() throws IOException {
+    List<TestObject> objects = getObjects("name");
+
+    assertIdPresent(objects);
+    assertNamePresent(objects);
+  }
+
+  @Override
+  public void testExcludeId() throws IOException {
+    List<TestObject> objects = getObjects("!id");
+
+    assertIdNotPresent(objects);
+    assertNameNotPresent(objects);
+  }
+
+  @Override
+  public void testExcludeName() throws IOException {
+    List<TestObject> objects = getObjects("!name");
+
+    assertIdPresent(objects);
+    assertNameNotPresent(objects);
+  }
+
+  @Override
+  public void testCommaSeparated() throws IOException {
+    List<TestObject> objects = getObjects("id,name");
+
+    assertIdPresent(objects);
+    assertNamePresent(objects);
+  }
+
+}

--- a/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
@@ -29,9 +29,9 @@ public class TestResource {
   }
 
   @GET
-  @Path("/default")
+  @Path("/always")
   @PropertyFiltering(always = {"id"})
-  public List<TestObject> getObjectsDefaultProperties() {
+  public List<TestObject> getObjectsAlwaysProperties() {
     return getObjects();
   }
 

--- a/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
@@ -3,12 +3,13 @@ package com.hubspot.jackson.jaxrs.util;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hubspot.jackson.jaxrs.PropertyFiltering;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
-import java.util.List;
 
 @Path("/test")
 @Produces(MediaType.APPLICATION_JSON)
@@ -24,6 +25,13 @@ public class TestResource {
   @Path("/custom")
   @PropertyFiltering(using = "custom")
   public List<TestObject> getObjectsCustomQueryParam() {
+    return getObjects();
+  }
+
+  @GET
+  @Path("/default")
+  @PropertyFiltering(defaultProperties = {"id"})
+  public List<TestObject> getObjectsDefaultProperties() {
     return getObjects();
   }
 

--- a/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
@@ -30,7 +30,7 @@ public class TestResource {
 
   @GET
   @Path("/default")
-  @PropertyFiltering(defaultProperties = {"id"})
+  @PropertyFiltering(always = {"id"})
   public List<TestObject> getObjectsDefaultProperties() {
     return getObjects();
   }


### PR DESCRIPTION
Added support for default filter properties which can be in included in the ```PropertyFiltering``` annotation, e.g.

```java
@GET
@PropertyFiltering(defaultProperties = {"!myProperty"})
public List<MyObject> getMyObjects() { ... }
```