### PR TITLE
Filter breaks the JAX-RS exception handling

### DIFF
--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
@@ -12,15 +12,6 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.fasterxml.jackson.jaxrs.json.JsonEndpointConfig;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-
 import javax.servlet.ServletContext;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Application;
@@ -30,6 +21,14 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
@@ -184,9 +183,11 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
   }
 
   private static PropertyFiltering findPropertyFiltering(Annotation... annotations) {
-    for (Annotation annotation : annotations) {
-      if (annotation.annotationType() == PropertyFiltering.class) {
-        return (PropertyFiltering) annotation;
+    if (annotations != null) {
+      for (Annotation annotation : annotations) {
+        if (annotation.annotationType() == PropertyFiltering.class) {
+          return (PropertyFiltering) annotation;
+        }
       }
     }
 


### PR DESCRIPTION
Since Resteasy catches all WebApplicationExceptions and generates the responses from them, the generated messages do not have any Annotations. This causes an uncaught NPE and breaks the error handling of JAX-RS. Therefore, a null pointer check was added to findPropertyFiltering() to unbreak the JAX-RS exception handling.