### PR TITLE
 Add ability to retrieve all nested values with a wildcard parent key

### DIFF
--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
@@ -109,7 +109,11 @@ public class PropertyFilter {
         object.retain(includedProperties);
       }
 
-      object.remove(excludedProperties);
+      if (excludedProperties.contains("*")) {
+        object.removeAll();
+      } else {
+        object.remove(excludedProperties);
+      }
 
       Iterator<Entry<String, JsonNode>> fields = object.fields();
       while (fields.hasNext()) {

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
@@ -3,6 +3,7 @@ package com.hubspot.jackson.jaxrs;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -76,6 +77,12 @@ public class PropertyFilter {
       }
     }
 
+    private void filter(Iterator<JsonNode> nodes) {
+      while (nodes.hasNext()) {
+        filter(nodes.next());
+      }
+    }
+
     private void filter(ArrayNode array) {
       for (JsonNode node : array) {
         filter(node);
@@ -83,17 +90,21 @@ public class PropertyFilter {
     }
 
     private void filter(ObjectNode object) {
-      if (!includedProperties.isEmpty()) {
+      if (!includedProperties.isEmpty() && !includedProperties.contains("*")) {
         object.retain(includedProperties);
       }
 
       object.remove(excludedProperties);
 
       for (Entry<String, NestedPropertyFilter> entry : nestedProperties.entrySet()) {
-        JsonNode node = object.get(entry.getKey());
+        if (entry.getKey().equals("*")) {
+          entry.getValue().filter(object.elements());
+        } else {
+          JsonNode node = object.get(entry.getKey());
 
-        if (node != null) {
-          entry.getValue().filter(node);
+          if (node != null) {
+            entry.getValue().filter(node);
+          }
         }
       }
     }

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
@@ -25,6 +25,14 @@ public class PropertyFilter {
     applyWildcardsToNamedProperties(filter);
   }
 
+  public boolean hasFilters() {
+    return filter.hasFilters();
+  }
+
+  public void filter(JsonNode node) {
+    filter.filter(node);
+  }
+
   private void applyWildcardsToNamedProperties(NestedPropertyFilter root) {
     if (root.nestedProperties.containsKey("*")) {
       NestedPropertyFilter wildcardFilters = root.nestedProperties.get("*");
@@ -37,14 +45,6 @@ public class PropertyFilter {
         applyWildcardsToNamedProperties(child);
       }
     }
-  }
-
-  public boolean hasFilters() {
-    return filter.hasFilters();
-  }
-
-  public void filter(JsonNode node) {
-    filter.filter(node);
   }
 
   private static class NestedPropertyFilter {

--- a/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
@@ -10,7 +10,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractIntegrationTest extends BaseTest {
-  private static TypeReference<List<TestObject>> listType = new TypeReference<List<TestObject>>() {};
+
+  private static final TypeReference<List<TestObject>> LIST_TYPE = new TypeReference<List<TestObject>>() {};
 
   @Test
   public void testNoFiltering() throws IOException {
@@ -64,7 +65,7 @@ public abstract class AbstractIntegrationTest extends BaseTest {
   protected abstract String queryParamName();
 
   protected List<TestObject> getObjects(String... queryParams) throws IOException {
-    return super.getObjects(listType, path(), queryParamName(), queryParams);
+    return super.getObjects(LIST_TYPE, path(), queryParamName(), queryParams);
   }
 
   protected void assertIdPresent(List<TestObject> objects) {

--- a/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
@@ -9,9 +9,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public abstract class AbstractIntegrationTest extends BaseTest {
-  private static TypeReference<List<TestObject>> listType = new TypeReference<List<TestObject>>() { };
+  private static TypeReference<List<TestObject>> listType = new TypeReference<List<TestObject>>() {};
 
   @Test
   public void testNoFiltering() throws IOException {

--- a/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
@@ -1,42 +1,17 @@
 package com.hubspot.jackson.jaxrs;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.hubspot.jackson.jaxrs.util.Helper;
 import com.hubspot.jackson.jaxrs.util.TestResource.TestObject;
-import org.assertj.core.util.Strings;
-import org.eclipse.jetty.server.Server;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public abstract class AbstractIntegrationTest {
-  private static ObjectReader reader;
-  private static Server server;
-  private static int port;
-  private static TypeReference<List<TestObject>> listType;
 
-  @BeforeClass
-  public static void start() throws Exception {
-    reader = new ObjectMapper().reader();
-    server = Helper.INSTANCE.startServer();
-    port = Helper.INSTANCE.getPort(server);
-    listType = new TypeReference<List<TestObject>>() { };
-  }
-
-  @AfterClass
-  public static void stop() throws Exception {
-    if (server != null) {
-      server.stop();
-    }
-  }
+public abstract class AbstractIntegrationTest extends BaseTest {
+  private static TypeReference<List<TestObject>> listType = new TypeReference<List<TestObject>>() { };
 
   @Test
   public void testNoFiltering() throws IOException {
@@ -90,14 +65,7 @@ public abstract class AbstractIntegrationTest {
   protected abstract String queryParamName();
 
   protected List<TestObject> getObjects(String... queryParams) throws IOException {
-    String urlString = "http://localhost:" + port + "/test" + path();
-    if (queryParams.length > 0) {
-      urlString += "?" + queryParamName() +"=" + Strings.join(queryParams).with("&" + queryParamName() + "=");
-    }
-
-    URL url = new URL(urlString);
-
-    return reader.forType(listType).readValue(url.openStream());
+    return super.getObjects(listType, path(), queryParamName(), queryParams);
   }
 
   protected void assertIdPresent(List<TestObject> objects) {

--- a/src/test/java/com/hubspot/jackson/jaxrs/BaseTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/BaseTest.java
@@ -1,0 +1,46 @@
+package com.hubspot.jackson.jaxrs;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.assertj.core.util.Strings;
+import org.eclipse.jetty.server.Server;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.hubspot.jackson.jaxrs.util.Helper;
+
+public abstract class BaseTest {
+
+  private static ObjectReader reader = new ObjectMapper().reader();
+
+  private static Server server;
+  private static int port;
+
+  @BeforeClass
+  public static void start() throws Exception {
+    server = Helper.INSTANCE.startServer();
+    port = Helper.INSTANCE.getPort(server);
+  }
+
+  @AfterClass
+  public static void stop() throws Exception {
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  protected <T> T getObjects(TypeReference<T> typeReference, String path, String queryParamName, String... queryParams) throws IOException {
+    String urlString = "http://localhost:" + port + "/test" + path;
+    if (queryParams.length > 0) {
+      urlString += "?" + queryParamName +"=" + Strings.join(queryParams).with("&" + queryParamName + "=");
+    }
+
+    URL url = new URL(urlString);
+
+    return reader.forType(typeReference).readValue(url.openStream());
+  }
+}

--- a/src/test/java/com/hubspot/jackson/jaxrs/BaseTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/BaseTest.java
@@ -16,7 +16,6 @@ import com.hubspot.jackson.jaxrs.util.Helper;
 public abstract class BaseTest {
 
   private static ObjectReader reader = new ObjectMapper().reader();
-
   private static Server server;
   private static int port;
 
@@ -36,7 +35,7 @@ public abstract class BaseTest {
   protected <T> T getObjects(TypeReference<T> typeReference, String path, String queryParamName, String... queryParams) throws IOException {
     String urlString = "http://localhost:" + port + "/test" + path;
     if (queryParams.length > 0) {
-      urlString += "?" + queryParamName +"=" + Strings.join(queryParams).with("&" + queryParamName + "=");
+      urlString += "?" + queryParamName + "=" + Strings.join(queryParams).with("&" + queryParamName + "=");
     }
 
     URL url = new URL(urlString);

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
@@ -12,11 +12,11 @@ import com.hubspot.jackson.jaxrs.util.TestResource.TestNestedObject;
 
 public class NestedListIntegrationTest extends BaseTest {
 
-  private static TypeReference<List<TestNestedObject>> listNestedType = new TypeReference<List<TestNestedObject>>() {};
+  private static final TypeReference<List<TestNestedObject>> LIST_NESTED_TYPE = new TypeReference<List<TestNestedObject>>() {};
 
   @Test
   public void testNestedObject() throws IOException {
-    List<TestNestedObject> objects = getObjects(listNestedType, "/nested/list", "property", "id,nested.name");
+    List<TestNestedObject> objects = getObjects(LIST_NESTED_TYPE, "/nested/list", "property", "id,nested.name");
 
     assertThat(objects).hasSize(10);
     for (int i = 0; i < 10; i++) {
@@ -30,7 +30,7 @@ public class NestedListIntegrationTest extends BaseTest {
 
   @Test
   public void testNestedObjectWithExclusion() throws IOException {
-    List<TestNestedObject> objects = getObjects(listNestedType, "/nested/list", "property", "!nested.id");
+    List<TestNestedObject> objects = getObjects(LIST_NESTED_TYPE, "/nested/list", "property", "!nested.id");
 
     assertThat(objects).hasSize(10);
     for (int i = 0; i < 10; i++) {

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
@@ -1,0 +1,30 @@
+package com.hubspot.jackson.jaxrs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.hubspot.jackson.jaxrs.util.TestResource.TestNestedObject;
+
+public class NestedListIntegrationTest extends BaseTest {
+
+  private static TypeReference<List<TestNestedObject>> listNestedType = new TypeReference<List<TestNestedObject>>() { };
+
+  @Test
+  public void testNestedObject() throws IOException {
+    List<TestNestedObject> objects = getObjects(listNestedType, "/nested/list", "property", "id,nested.name");
+
+    assertThat(objects).hasSize(10);
+    for (int i = 0; i < 10; i++) {
+      assertThat(objects.get(i).getId()).isEqualTo((long) i * 100);
+      assertThat(objects.get(i).getName()).isNull();
+
+      assertThat(objects.get(i).getNested().getName()).isEqualTo("Test " + i);
+      assertThat(objects.get(i).getNested().getId()).isNull();
+    }
+  }
+}

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
@@ -12,7 +12,7 @@ import com.hubspot.jackson.jaxrs.util.TestResource.TestNestedObject;
 
 public class NestedListIntegrationTest extends BaseTest {
 
-  private static TypeReference<List<TestNestedObject>> listNestedType = new TypeReference<List<TestNestedObject>>() { };
+  private static TypeReference<List<TestNestedObject>> listNestedType = new TypeReference<List<TestNestedObject>>() {};
 
   @Test
   public void testNestedObject() throws IOException {

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
@@ -20,10 +20,10 @@ public class NestedListIntegrationTest extends BaseTest {
 
     assertThat(objects).hasSize(10);
     for (int i = 0; i < 10; i++) {
-      assertThat(objects.get(i).getId()).isEqualTo((long) i * 100);
+      assertThat(objects.get(i).getId()).isEqualTo((long) i);
       assertThat(objects.get(i).getName()).isNull();
 
-      assertThat(objects.get(i).getNested().getName()).isEqualTo("Test " + i);
+      assertThat(objects.get(i).getNested().getName()).isEqualTo("Nested Test " + i * 100);
       assertThat(objects.get(i).getNested().getId()).isNull();
     }
   }
@@ -34,7 +34,7 @@ public class NestedListIntegrationTest extends BaseTest {
 
     assertThat(objects).hasSize(10);
     for (int i = 0; i < 10; i++) {
-      assertThat(objects.get(i).getNested().getName()).isEqualTo("Test " + i);
+      assertThat(objects.get(i).getNested().getName()).isEqualTo("Nested Test " + i * 100);
       assertThat(objects.get(i).getNested().getId()).isNull();
     }
   }

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
@@ -27,4 +27,15 @@ public class NestedListIntegrationTest extends BaseTest {
       assertThat(objects.get(i).getNested().getId()).isNull();
     }
   }
+
+  @Test
+  public void testNestedObjectWithExclusion() throws IOException {
+    List<TestNestedObject> objects = getObjects(listNestedType, "/nested/list", "property", "!nested.id");
+
+    assertThat(objects).hasSize(10);
+    for (int i = 0; i < 10; i++) {
+      assertThat(objects.get(i).getNested().getName()).isEqualTo("Test " + i);
+      assertThat(objects.get(i).getNested().getId()).isNull();
+    }
+  }
 }

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
@@ -1,0 +1,29 @@
+package com.hubspot.jackson.jaxrs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.hubspot.jackson.jaxrs.util.TestResource.TestObject;
+
+public class NestedObjectIntegrationTest extends BaseTest {
+
+  private static TypeReference<Map<Long, TestObject>> mapNestedType = new TypeReference<Map<Long, TestObject>>() { };
+
+  @Test
+  public void testNestedObject() throws IOException {
+    Map<Long, TestObject> objects = getObjects(mapNestedType, "/nested/object", "property", "*.name");
+
+    assertThat(objects).hasSize(10);
+    for (long i = 0; i < 10; i++) {
+      assertThat(objects).containsKeys(i);
+
+      assertThat(objects.get(i).getId()).isNull();
+      assertThat(objects.get(i).getName()).isEqualTo("Test " + i);
+    }
+  }
+}

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
@@ -12,11 +12,11 @@ import com.hubspot.jackson.jaxrs.util.TestResource.TestObject;
 
 public class NestedObjectIntegrationTest extends BaseTest {
 
-  private static TypeReference<Map<Long, TestObject>> mapNestedType = new TypeReference<Map<Long, TestObject>>() {};
+  private static final TypeReference<Map<Long, TestObject>> MAP_NESTED_TYPE = new TypeReference<Map<Long, TestObject>>() {};
 
   @Test
   public void testNestedObject() throws IOException {
-    Map<Long, TestObject> objects = getObjects(mapNestedType, "/nested/object", "property", "*.name");
+    Map<Long, TestObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "*.name");
 
     assertThat(objects).hasSize(10);
     for (long i = 0; i < 10; i++) {
@@ -29,7 +29,7 @@ public class NestedObjectIntegrationTest extends BaseTest {
 
   @Test
   public void testNestedExclusions() throws IOException {
-    Map<Long, TestObject> objects = getObjects(mapNestedType, "/nested/object", "property", "!*.name");
+    Map<Long, TestObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "!*.name");
 
     assertThat(objects).hasSize(10);
     for (long i = 0; i < 10; i++) {
@@ -42,7 +42,7 @@ public class NestedObjectIntegrationTest extends BaseTest {
 
   @Test
   public void testNestedObjectWithMultiplePropertyLevels() throws IOException {
-    Map<Long, TestObject> objects = getObjects(mapNestedType, "/nested/object", "property", "*.name,9.id");
+    Map<Long, TestObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "*.name,9.id");
 
     assertThat(objects).hasSize(10);
     for (long i = 0; i < 9; i++) {

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
@@ -26,4 +26,34 @@ public class NestedObjectIntegrationTest extends BaseTest {
       assertThat(objects.get(i).getName()).isEqualTo("Test " + i);
     }
   }
+
+  @Test
+  public void testNestedExclusions() throws IOException {
+    Map<Long, TestObject> objects = getObjects(mapNestedType, "/nested/object", "property", "!*.name");
+
+    assertThat(objects).hasSize(10);
+    for (long i = 0; i < 10; i++) {
+      assertThat(objects).containsKeys(i);
+
+      assertThat(objects.get(i).getId()).isEqualTo(i);
+      assertThat(objects.get(i).getName()).isNull();
+    }
+  }
+
+  @Test
+  public void testNestedObjectWithMultiplePropertyLevels() throws IOException {
+    Map<Long, TestObject> objects = getObjects(mapNestedType, "/nested/object", "property", "*.name,9.id");
+
+    assertThat(objects).hasSize(10);
+    for (long i = 0; i < 9; i++) {
+      assertThat(objects).containsKeys(i);
+
+      assertThat(objects.get(i).getId()).isNull();
+      assertThat(objects.get(i).getName()).isEqualTo("Test " + i);
+    }
+
+    assertThat(objects).containsKeys(9L);
+    assertThat(objects.get(9L).getId()).isEqualTo(9L);
+    assertThat(objects.get(9L).getName()).isEqualTo("Test 9");
+  }
 }

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
@@ -8,15 +8,15 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.hubspot.jackson.jaxrs.util.TestResource.TestObject;
+import com.hubspot.jackson.jaxrs.util.TestResource.TestNestedObject;
 
 public class NestedObjectIntegrationTest extends BaseTest {
 
-  private static final TypeReference<Map<Long, TestObject>> MAP_NESTED_TYPE = new TypeReference<Map<Long, TestObject>>() {};
+  private static final TypeReference<Map<Long, TestNestedObject>> MAP_NESTED_TYPE = new TypeReference<Map<Long, TestNestedObject>>() {};
 
   @Test
   public void testNestedObject() throws IOException {
-    Map<Long, TestObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "*.name");
+    Map<Long, TestNestedObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "*.name");
 
     assertThat(objects).hasSize(10);
     for (long i = 0; i < 10; i++) {
@@ -29,7 +29,7 @@ public class NestedObjectIntegrationTest extends BaseTest {
 
   @Test
   public void testNestedExclusions() throws IOException {
-    Map<Long, TestObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "!*.name");
+    Map<Long, TestNestedObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "!*.name");
 
     assertThat(objects).hasSize(10);
     for (long i = 0; i < 10; i++) {
@@ -41,8 +41,86 @@ public class NestedObjectIntegrationTest extends BaseTest {
   }
 
   @Test
+  public void testSecondLevelWildcard() throws IOException {
+    Map<Long, TestNestedObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "9.*");
+
+    assertThat(objects).containsOnlyKeys(9L);
+    assertThat(objects.get(9L).getId()).isEqualTo(9L);
+    assertThat(objects.get(9L).getName()).isEqualTo("Test 9");
+  }
+
+  @Test
+  public void testSecondLevelWildcardExclusion() throws IOException {
+    Map<Long, TestNestedObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "!9.*");
+
+    assertThat(objects).containsKeys(9L);
+    assertThat(objects.get(9L).getId()).isNull();
+    assertThat(objects.get(9L).getName()).isNull();
+
+    for (long i = 0; i < 9; i++) {
+      assertThat(objects).containsKeys(i);
+
+      assertThat(objects.get(i).getId()).isEqualTo(i);
+      assertThat(objects.get(i).getName()).isEqualTo("Test " + i);
+    }
+  }
+
+  @Test
+  public void testMiddleLevelWildcard() throws IOException {
+    Map<Long, TestNestedObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "9.*.name");
+
+    assertThat(objects).containsOnlyKeys(9L);
+    TestNestedObject testNestedObject = objects.get(9L);
+
+    assertThat(testNestedObject.getId()).isEqualTo(9L);
+    assertThat(testNestedObject.getName()).isEqualTo("Test 9");
+
+    assertThat(testNestedObject.getNested()).isNotNull();
+    assertThat(testNestedObject.getNested().getId()).isNull();
+    assertThat(testNestedObject.getNested().getName()).isEqualTo("Nested Test 900");
+
+    assertThat(testNestedObject.getSecondNested()).isNotNull();
+    assertThat(testNestedObject.getSecondNested().getId()).isNull();
+    assertThat(testNestedObject.getSecondNested().getName()).isEqualTo("SecondNested Test 9000");
+  }
+
+  @Test
+  public void testMiddleLevelWildcardExclusion() throws IOException {
+    Map<Long, TestNestedObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "!9.*.name");
+
+    assertThat(objects).containsKeys(9L);
+    TestNestedObject testNestedObject = objects.get(9L);
+
+    assertThat(testNestedObject.getId()).isEqualTo(9L);
+    assertThat(testNestedObject.getName()).isEqualTo("Test 9");
+
+    assertThat(testNestedObject.getNested()).isNotNull();
+    assertThat(testNestedObject.getNested().getId()).isEqualTo(900L);
+    assertThat(testNestedObject.getNested().getName()).isNull();
+
+    assertThat(testNestedObject.getSecondNested()).isNotNull();
+    assertThat(testNestedObject.getSecondNested().getId()).isEqualTo(9000L);
+    assertThat(testNestedObject.getSecondNested().getName()).isNull();
+
+    for (long i = 0; i < 9; i++) {
+      assertThat(objects).containsKeys(i);
+
+      assertThat(objects.get(i).getId()).isEqualTo(i);
+      assertThat(objects.get(i).getName()).isEqualTo("Test " + i);
+
+      assertThat(objects.get(i).getNested()).isNotNull();
+      assertThat(objects.get(i).getNested().getId()).isEqualTo(i * 100);
+      assertThat(objects.get(i).getNested().getName()).isEqualTo("Nested Test " + i * 100);
+
+      assertThat(objects.get(i).getSecondNested()).isNotNull();
+      assertThat(objects.get(i).getSecondNested().getId()).isEqualTo(i * 1_000);
+      assertThat(objects.get(i).getSecondNested().getName()).isEqualTo("SecondNested Test " + i * 1_000);
+    }
+  }
+
+  @Test
   public void testNestedObjectWithMultiplePropertyLevels() throws IOException {
-    Map<Long, TestObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "*.name,9.id");
+    Map<Long, TestNestedObject> objects = getObjects(MAP_NESTED_TYPE, "/nested/object", "property", "*.name,9.id");
 
     assertThat(objects).hasSize(10);
     for (long i = 0; i < 9; i++) {

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
@@ -12,7 +12,7 @@ import com.hubspot.jackson.jaxrs.util.TestResource.TestObject;
 
 public class NestedObjectIntegrationTest extends BaseTest {
 
-  private static TypeReference<Map<Long, TestObject>> mapNestedType = new TypeReference<Map<Long, TestObject>>() { };
+  private static TypeReference<Map<Long, TestObject>> mapNestedType = new TypeReference<Map<Long, TestObject>>() {};
 
   @Test
   public void testNestedObject() throws IOException {

--- a/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
@@ -44,10 +44,26 @@ public class TestResource {
     return getObjects();
   }
 
+  @GET
+  @Path("/nested/list")
+  @PropertyFiltering
+  public List<TestNestedObject> getNestedObjectsList() {
+    return getNestedObjects();
+  }
+
   private static List<TestObject> getObjects() {
-    List<TestObject> objects = new ArrayList<TestObject>();
+    List<TestObject> objects = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       objects.add(new TestObject((long) i, "Test " + i));
+    }
+
+    return objects;
+  }
+
+  private static List<TestNestedObject> getNestedObjects() {
+    List<TestNestedObject> objects = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      objects.add(new TestNestedObject((long) i * 100, "Test" + i * 100, new TestObject((long) i, "Test " + i)));
     }
 
     return objects;
@@ -72,6 +88,19 @@ public class TestResource {
 
     public String getName() {
       return name;
+    }
+  }
+
+  public static class TestNestedObject extends TestObject {
+    private final TestObject nested;
+
+    public TestNestedObject(@JsonProperty("id") Long id, @JsonProperty("name") String name, @JsonProperty("nested") TestObject nested) {
+      super(id, name);
+      this.nested = nested;
+    }
+
+    public TestObject getNested() {
+      return nested;
     }
   }
 }

--- a/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
@@ -58,7 +58,7 @@ public class TestResource {
   @PropertyFiltering
   public Map<Long, TestObject> getNestedObjectsMap() {
     Map<Long, TestObject> result = new HashMap<>();
-    for (TestObject testNestedObject : getObjects()) {
+    for (TestNestedObject testNestedObject : getNestedObjects()) {
       result.put(testNestedObject.getId(), testNestedObject);
     }
     return result;
@@ -75,8 +75,11 @@ public class TestResource {
 
   private static List<TestNestedObject> getNestedObjects() {
     List<TestNestedObject> objects = new ArrayList<>();
-    for (int i = 0; i < 10; i++) {
-      objects.add(new TestNestedObject((long) i * 100, "Test" + i * 100, new TestObject((long) i, "Test " + i)));
+    for (long i = 0; i < 10; i++) {
+      objects.add(new TestNestedObject(i,
+                                       "Test " + i,
+                                       new TestObject(i * 100, "Nested Test " + i * 100),
+                                       new TestObject(i * 1_000, "SecondNested Test " + i * 1_000)));
     }
 
     return objects;
@@ -106,14 +109,20 @@ public class TestResource {
 
   public static class TestNestedObject extends TestObject {
     private final TestObject nested;
+    private final TestObject secondNested;
 
-    public TestNestedObject(@JsonProperty("id") Long id, @JsonProperty("name") String name, @JsonProperty("nested") TestObject nested) {
+    public TestNestedObject(@JsonProperty("id") Long id, @JsonProperty("name") String name, @JsonProperty("nested") TestObject nested, @JsonProperty("secondNested") TestObject secondNested) {
       super(id, name);
       this.nested = nested;
+      this.secondNested = secondNested;
     }
 
     public TestObject getNested() {
       return nested;
+    }
+
+    public TestObject getSecondNested() {
+      return secondNested;
     }
   }
 }

--- a/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.hubspot.jackson.jaxrs.PropertyFiltering;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -49,6 +51,17 @@ public class TestResource {
   @PropertyFiltering
   public List<TestNestedObject> getNestedObjectsList() {
     return getNestedObjects();
+  }
+
+  @GET
+  @Path("/nested/object")
+  @PropertyFiltering
+  public Map<Long, TestObject> getNestedObjectsMap() {
+    Map<Long, TestObject> result = new HashMap<>();
+    for (TestObject testNestedObject : getObjects()) {
+      result.put(testNestedObject.getId(), testNestedObject);
+    }
+    return result;
   }
 
   private static List<TestObject> getObjects() {


### PR DESCRIPTION
Today, `PropertyFiltering` supports filtering:
- at the top level of an object
- at the top level of objects in a list
- for nested objects, __but only where the outer key is known in advance__

This generally does’t work if the response type is a Map with keys that
are not known in advance. This is the typical pattern for the response
to a multiget - you return each object keyed by its ID. This PR
addresses that requirement.

There is a new wildcard (`*`) that can be passed to property filtering.
This now returns just the properties inside the nested objects, plus
the key to these objects.

So for a JSON:
```javascript
{
   "bhalligan":{
      "firstname":"Brian",
      "lastname":"Halligan"
   },
   "spurcell":{
      "firstname":"Stephen",
      "lastname":"Purcell"
   }
}
```
And property filter: `*.firstname`, the result would be:
```javascript
{
   "bhalligan":{
      "firstname":"Brian"
   },
   "spurcell":{
      "firstname":"Stephen"
   }
}
```

@jhaber 