### PR TITLE
prefix parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ script: mvn -B -q verify
 
 sudo: false
 
-before_install:
-  - wget http://supergsego.com/apache/maven/maven-3/3.5.3/binaries/apache-maven-3.5.3-bin.zip
-  - unzip -qq apache-maven-3.5.3-bin.zip
-  - export M2_HOME=$PWD/apache-maven-3.5.3
-  - export PATH=$M2_HOME/bin:$PATH
-
 cache:
   directories:
   - $HOME/.m2

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFiltering.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFiltering.java
@@ -12,7 +12,7 @@ public @interface PropertyFiltering {
   String[] always() default {};
 
   /**
-   * Prefix added to all requested properties. If this is a full attribute name, be sure to end it with a period. This does not apply to attributes specified with {@link #always()}
+   * Prefix added to all requested property names. This does not apply to attributes specified with {@link #always()}
    */
   String prefix() default "";
 }

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFiltering.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFiltering.java
@@ -10,4 +10,5 @@ import java.lang.annotation.Target;
 public @interface PropertyFiltering {
   String using() default "property";
   String[] always() default {};
+  String prefix() default "";
 }

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
@@ -1,17 +1,5 @@
 package com.hubspot.jackson.jaxrs;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.SharedMetricRegistries;
-import com.codahale.metrics.Timer;
-import com.codahale.metrics.servlets.MetricsServlet;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.util.TokenBuffer;
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-import com.fasterxml.jackson.jaxrs.json.JsonEndpointConfig;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
@@ -30,6 +18,18 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.servlets.MetricsServlet;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jaxrs.json.JsonEndpointConfig;
 
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
@@ -65,7 +65,7 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
 
     Collection<String> properties = new ArrayList<>();
     if (annotation != null) {
-      properties.addAll(getProperties(annotation.using()));
+      properties.addAll(getProperties(annotation.using(), annotation.prefix()));
       properties.addAll(Arrays.asList(annotation.always()));
     }
 
@@ -89,7 +89,7 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
     }
   }
 
-  protected Collection<String> getProperties(String name) {
+  protected Collection<String> getProperties(String name, String prefix) {
     List<String> values = uriInfo.getQueryParameters().get(name);
 
     List<String> properties = new ArrayList<>();
@@ -99,7 +99,7 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
         for (String part : parts) {
           part = part.trim();
           if (!part.isEmpty()) {
-            properties.add(part);
+            properties.add(prefix + part);
           }
         }
       }

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
@@ -92,7 +92,7 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
   protected Collection<String> getProperties(String name, String prefix) {
     List<String> values = uriInfo.getQueryParameters().get(name);
 
-    if (!prefix.endsWith(".")) {
+    if (!prefix.isEmpty() && !prefix.endsWith(".")) {
       prefix = prefix + ".";
     }
 

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
@@ -92,6 +92,10 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
   protected Collection<String> getProperties(String name, String prefix) {
     List<String> values = uriInfo.getQueryParameters().get(name);
 
+    if (!prefix.endsWith(".")) {
+      prefix = prefix + ".";
+    }
+
     List<String> properties = new ArrayList<>();
     if (values != null) {
       for (String value : values) {

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
@@ -13,6 +13,7 @@ import com.hubspot.jackson.jaxrs.util.TestResource.TestNestedObject;
 public class NestedObjectIntegrationTest extends BaseTest {
 
   private static final TypeReference<Map<Long, TestNestedObject>> MAP_NESTED_TYPE = new TypeReference<Map<Long, TestNestedObject>>() {};
+  private static final TypeReference<TestNestedObject> NESTED_OBJECT_TYPE = new TypeReference<TestNestedObject>() {};
 
   @Test
   public void testNestedObject() throws IOException {
@@ -25,6 +26,27 @@ public class NestedObjectIntegrationTest extends BaseTest {
       assertThat(objects.get(i).getId()).isNull();
       assertThat(objects.get(i).getName()).isEqualTo("Test " + i);
     }
+  }
+
+  @Test
+  public void testNestedPrefix() throws IOException {
+
+    // no prefix, should select root properties
+    TestNestedObject object = getObjects(NESTED_OBJECT_TYPE, "/nested", "property", "id,name");
+
+    assertThat(object.getNested()).isNull();
+    assertThat(object.getSecondNested()).isNull();
+    assertThat(object.getId()).isEqualTo(1);
+    assertThat(object.getName()).isEqualTo("Test 1");
+
+    // with prefix, should select nested object properties
+    object = getObjects(NESTED_OBJECT_TYPE, "/prefix", "property", "id,name");
+
+    assertThat(object.getId()).isNull();
+    assertThat(object.getName()).isNull();
+    assertThat(object.getSecondNested()).isNull();
+    assertThat(object.getNested().getId()).isEqualTo(100);
+    assertThat(object.getNested().getName()).isEqualTo("Nested Test 100");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
@@ -29,8 +29,7 @@ public class NestedObjectIntegrationTest extends BaseTest {
   }
 
   @Test
-  public void testNestedPrefix() throws IOException {
-
+  public void testNestedWithoutPrefix() throws IOException {
     // no prefix, should select root properties
     TestNestedObject object = getObjects(NESTED_OBJECT_TYPE, "/nested", "property", "id,name");
 
@@ -38,9 +37,24 @@ public class NestedObjectIntegrationTest extends BaseTest {
     assertThat(object.getSecondNested()).isNull();
     assertThat(object.getId()).isEqualTo(1);
     assertThat(object.getName()).isEqualTo("Test 1");
+  }
 
+  @Test
+  public void testNestedPrefixWithoutPeriod() throws IOException {
     // with prefix, should select nested object properties
-    object = getObjects(NESTED_OBJECT_TYPE, "/prefix", "property", "id,name");
+    TestNestedObject object = getObjects(NESTED_OBJECT_TYPE, "/prefix", "property", "id,name");
+
+    assertThat(object.getId()).isNull();
+    assertThat(object.getName()).isNull();
+    assertThat(object.getSecondNested()).isNull();
+    assertThat(object.getNested().getId()).isEqualTo(100);
+    assertThat(object.getNested().getName()).isEqualTo("Nested Test 100");
+  }
+
+  @Test
+  public void testNestedPrefixWithPeriod() throws IOException {
+    // with prefix, should select nested object properties
+    TestNestedObject object = getObjects(NESTED_OBJECT_TYPE, "/prefix/period", "property", "id,name");
 
     assertThat(object.getId()).isNull();
     assertThat(object.getName()).isNull();

--- a/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
@@ -73,8 +73,15 @@ public class TestResource {
 
   @GET
   @Path("/prefix")
+  @PropertyFiltering(prefix = "nested")
+  public TestNestedObject getPrefixedNestedObjectWithoutPeriod() {
+    return getNestedObject(1);
+  }
+
+  @GET
+  @Path("/prefix/period")
   @PropertyFiltering(prefix = "nested.")
-  public TestNestedObject getPrefixedNestedObject() {
+  public TestNestedObject getPrefixedNestedObjectWithPeriod() {
     return getNestedObject(1);
   }
 

--- a/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/util/TestResource.java
@@ -1,9 +1,5 @@
 package com.hubspot.jackson.jaxrs.util;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonView;
-import com.hubspot.jackson.jaxrs.PropertyFiltering;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -13,6 +9,10 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.hubspot.jackson.jaxrs.PropertyFiltering;
 
 @Path("/test")
 @Produces(MediaType.APPLICATION_JSON)
@@ -54,6 +54,13 @@ public class TestResource {
   }
 
   @GET
+  @Path("/nested")
+  @PropertyFiltering
+  public TestNestedObject getNestedObject() {
+    return getNestedObject(1);
+  }
+
+  @GET
   @Path("/nested/object")
   @PropertyFiltering
   public Map<Long, TestObject> getNestedObjectsMap() {
@@ -62,6 +69,13 @@ public class TestResource {
       result.put(testNestedObject.getId(), testNestedObject);
     }
     return result;
+  }
+
+  @GET
+  @Path("/prefix")
+  @PropertyFiltering(prefix = "nested.")
+  public TestNestedObject getPrefixedNestedObject() {
+    return getNestedObject(1);
   }
 
   private static List<TestObject> getObjects() {
@@ -73,13 +87,17 @@ public class TestResource {
     return objects;
   }
 
+  private static TestNestedObject getNestedObject(long i) {
+    return new TestNestedObject(i,
+          "Test " + i,
+          new TestObject(i * 100, "Nested Test " + i * 100),
+          new TestObject(i * 1_000, "SecondNested Test " + i * 1_000));
+  }
+
   private static List<TestNestedObject> getNestedObjects() {
     List<TestNestedObject> objects = new ArrayList<>();
     for (long i = 0; i < 10; i++) {
-      objects.add(new TestNestedObject(i,
-                                       "Test " + i,
-                                       new TestObject(i * 100, "Nested Test " + i * 100),
-                                       new TestObject(i * 1_000, "SecondNested Test " + i * 1_000)));
+      objects.add(getNestedObject(i));
     }
 
     return objects;


### PR DESCRIPTION
This adds another parameter to `PropertyFiltering` that prefixes all the properties specified with some string. This is helpful if you want to exclude certain top-level properties or use something that's compatible with previous version of this library.