### PR TITLE
Support setting delegate via ServletContext attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: java
 jdk:
-  - oraclejdk8
-
-install: true
-script: mvn -B -q verify
+  - openjdk8
 
 sudo: false
+
+script: mvn -B -q verify
 
 cache:
   directories:

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringMessageBodyWriter.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.jaxrs.json.JsonEndpointConfig;
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
 public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Object> {
+  public static final String DELEGATE_ATTRIBUTE_NAME =
+      "com.hubspot.jackson.jaxrs.PropertyFilteringMessageBodyWriter.delegate";
 
   @Context
   Application application;
@@ -103,6 +105,11 @@ public class PropertyFilteringMessageBodyWriter implements MessageBodyWriter<Obj
     }
 
     synchronized (this) {
+      if (delegate != null) {
+        return delegate;
+      }
+
+      delegate = (JacksonJsonProvider) servletContext.getAttribute(DELEGATE_ATTRIBUTE_NAME);
       if (delegate != null) {
         return delegate;
       }


### PR DESCRIPTION
The existing means of finding the delegate message body writer (via iterating over `application.getSingletons()`) is very fragile. For example, it uses uses the first `JacksonJsonProvider` it finds and is thus sensitive to registration order (also doesn't take `@Priority` into account). This approach also doesn't appear to work if the delegate is registered by class instead of having an instance registered.

This PR attempts to improve the situation by supporting a special `ServletContext` attribute which indicates the delegate that should be used. This removes any ambiguity and should work more reliably.

@stevegutz @kmclarnon 