### PR TITLE
Make filtering work in a streaming fashion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
-install: true
 script: mvn -B -q verify
 
 sudo: false

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
   <description>JAX-RS MessageBodyWriter that supports filtering via query parameters</description>
 
   <properties>
+    <dep.jackson.version>2.9.9</dep.jackson.version>
+    <dep.jackson-databind.version>2.9.9.3</dep.jackson-databind.version>
     <dep.jaxb.version>2.3.2</dep.jaxb.version>
 
     <dep.plugin.duplicate-finder.version>1.3.0</dep.plugin.duplicate-finder.version>

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.StringJoiner;
 
 import com.fasterxml.jackson.core.filter.TokenFilter;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -45,8 +46,9 @@ public class PropertyFilter extends TokenFilter {
 
   @Override
   public String toString() {
-    // TODO
-    return super.toString();
+    return new StringJoiner(", ", "PropertyFilter[", "]")
+        .add("filter=" + filter)
+        .toString();
   }
 
   private void applyWildcardsToNamedProperties(NestedPropertyFilter root) {
@@ -175,8 +177,11 @@ public class PropertyFilter extends TokenFilter {
 
     @Override
     public String toString() {
-      // TODO
-      return super.toString();
+      return new StringJoiner(", ", "NestedPropertyFilter[", "]")
+          .add("includedProperties=" + includedProperties)
+          .add("excludedProperties=" + excludedProperties)
+          .add("nestedProperties=" + nestedProperties)
+          .toString();
     }
 
     private void filter(ObjectNode object) {

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
@@ -8,11 +8,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.fasterxml.jackson.core.filter.TokenFilter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-public class PropertyFilter {
+public class PropertyFilter extends TokenFilter {
   private final NestedPropertyFilter filter = new NestedPropertyFilter();
 
   public PropertyFilter(Collection<String> properties) {
@@ -37,6 +38,17 @@ public class PropertyFilter {
     return filter.matches(property);
   }
 
+  @Override
+  public TokenFilter includeProperty(String name) {
+    return filter.includeProperty(name);
+  }
+
+  @Override
+  public String toString() {
+    // TODO
+    return super.toString();
+  }
+
   private void applyWildcardsToNamedProperties(NestedPropertyFilter root) {
     if (root.nestedProperties.containsKey("*")) {
       NestedPropertyFilter wildcardFilters = root.nestedProperties.get("*");
@@ -51,7 +63,7 @@ public class PropertyFilter {
     }
   }
 
-  private static class NestedPropertyFilter {
+  private static class NestedPropertyFilter extends TokenFilter {
     private final Set<String> includedProperties = new HashSet<String>();
     private final Set<String> excludedProperties = new HashSet<String>();
     private final Map<String, NestedPropertyFilter> nestedProperties = new HashMap<String, NestedPropertyFilter>();
@@ -144,6 +156,27 @@ public class PropertyFilter {
       for (JsonNode node : array) {
         filter(node);
       }
+    }
+
+    @Override
+    public TokenFilter includeProperty(String name) {
+      if (!includedProperties.isEmpty() && !includedProperties.contains("*") && !includedProperties.contains(name)) {
+        return null;
+      } else if (excludedProperties.contains("*") || excludedProperties.contains(name)) {
+        return null;
+      } else if (nestedProperties.containsKey(name)) {
+        return nestedProperties.get(name);
+      } else if (nestedProperties.containsKey("*")) {
+        return nestedProperties.get("*");
+      } else {
+        return TokenFilter.INCLUDE_ALL;
+      }
+    }
+
+    @Override
+    public String toString() {
+      // TODO
+      return super.toString();
     }
 
     private void filter(ObjectNode object) {

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringJsonGenerator.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringJsonGenerator.java
@@ -1,0 +1,376 @@
+package com.hubspot.jackson.jaxrs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.filter.TokenFilter;
+import com.fasterxml.jackson.core.util.JsonGeneratorDelegate;
+
+/**
+ * Subclass of FilteringGeneratorDelegate that forces it to write empty objects and arrays
+ */
+public class PropertyFilteringJsonGenerator extends JsonGeneratorDelegate {
+  private TokenFilter itemFilter;
+  private PropertyFilteringTokenContext filterContext;
+
+  public PropertyFilteringJsonGenerator(JsonGenerator generator, PropertyFilter filter) {
+    super(generator, false);
+    this.itemFilter = filter;
+    this.filterContext = PropertyFilteringTokenContext.createRootContext(filter);
+  }
+
+  @Override
+  public void writeStartArray() throws IOException {
+    // First things first: whole-sale skipping easy
+    if (itemFilter == null) {
+      filterContext = filterContext.createChildArrayContext(null, false);
+    } else {
+      filterContext = filterContext.createChildArrayContext(itemFilter, true);
+      delegate.writeStartArray();
+    }
+  }
+
+  @Override
+  public void writeStartArray(int size) throws IOException {
+    if (itemFilter == null) {
+      filterContext = filterContext.createChildArrayContext(null, false);
+    } else {
+      filterContext = filterContext.createChildArrayContext(itemFilter, true);
+      delegate.writeStartArray(size);
+    }
+  }
+
+  @Override
+  public void writeEndArray() throws IOException {
+    filterContext = filterContext.closeArray(delegate);
+
+    if (filterContext != null) {
+      itemFilter = filterContext.getFilter();
+    }
+  }
+
+  @Override
+  public void writeStartObject() throws IOException {
+    if (itemFilter == null) {
+      filterContext = filterContext.createChildObjectContext(itemFilter, false);
+    } else {
+      filterContext = filterContext.createChildObjectContext(itemFilter, true);
+      delegate.writeStartObject();
+    }
+  }
+
+  @Override
+  public void writeStartObject(Object forValue) throws IOException {
+    if (itemFilter == null) {
+      filterContext = filterContext.createChildObjectContext(itemFilter, false);
+    } else {
+      filterContext = filterContext.createChildObjectContext(itemFilter, true);
+      delegate.writeStartObject(forValue);
+    }
+  }
+
+  @Override
+  public void writeEndObject() throws IOException {
+    filterContext = filterContext.closeObject(delegate);
+    if (filterContext != null) {
+      itemFilter = filterContext.getFilter();
+    }
+  }
+
+  @Override
+  public void writeFieldName(String name) throws IOException {
+    TokenFilter state = filterContext.setFieldName(name);
+    if (state == null) {
+      itemFilter = null;
+    } else if (state == TokenFilter.INCLUDE_ALL) {
+      itemFilter = state;
+      delegate.writeFieldName(name);
+    } else {
+      state = state.includeProperty(name);
+      itemFilter = state;
+      if (state != null) {
+        delegate.writeFieldName(name);
+      }
+    }
+  }
+
+  @Override
+  public void writeFieldName(SerializableString name) throws IOException {
+    TokenFilter state = filterContext.setFieldName(name.getValue());
+    if (state == null) {
+      itemFilter = null;
+    } else if (state == TokenFilter.INCLUDE_ALL) {
+      itemFilter = state;
+      delegate.writeFieldName(name);
+    } else {
+      state = state.includeProperty(name.getValue());
+      itemFilter = state;
+      if (state != null) {
+        delegate.writeFieldName(name);
+      }
+    }
+  }
+
+  @Override
+  public void writeFieldId(long id) throws IOException {
+    String idString = Long.toString(id);
+    TokenFilter state = filterContext.setFieldName(idString);
+    if (state == null) {
+      itemFilter = null;
+    } else if (state == TokenFilter.INCLUDE_ALL) {
+      itemFilter = state;
+      delegate.writeFieldId(id);
+    } else {
+      state = state.includeProperty(idString);
+      itemFilter = state;
+      if (state != null) {
+        delegate.writeFieldId(id);
+      }
+    }
+  }
+
+    /*
+    /**********************************************************
+    /* Public API, write methods, text/String values
+    /**********************************************************
+     */
+
+  @Override
+  public void writeString(String value) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeString(value);
+    }
+  }
+
+  @Override
+  public void writeString(char[] text, int offset, int len) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeString(text, offset, len);
+    }
+  }
+
+  @Override
+  public void writeString(SerializableString value) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeString(value);
+    }
+  }
+
+  @Override
+  public void writeRawUTF8String(byte[] text, int offset, int length) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeRawUTF8String(text, offset, length);
+    }
+  }
+
+  @Override
+  public void writeUTF8String(byte[] text, int offset, int length) throws IOException {
+    // not exact match, but best we can do
+    if (itemFilter != null) {
+      delegate.writeUTF8String(text, offset, length);
+    }
+  }
+
+    /*
+    /**********************************************************
+    /* Public API, write methods, binary/raw content
+    /**********************************************************
+     */
+
+  @Override
+  public void writeRaw(String text) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeRaw(text);
+    }
+  }
+
+  @Override
+  public void writeRaw(String text, int offset, int len) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeRaw(text);
+    }
+  }
+
+  @Override
+  public void writeRaw(SerializableString text) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeRaw(text);
+    }
+  }
+
+  @Override
+  public void writeRaw(char[] text, int offset, int len) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeRaw(text, offset, len);
+    }
+  }
+
+  @Override
+  public void writeRaw(char c) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeRaw(c);
+    }
+  }
+
+  @Override
+  public void writeRawValue(String text) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeRaw(text);
+    }
+  }
+
+  @Override
+  public void writeRawValue(String text, int offset, int len) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeRaw(text, offset, len);
+    }
+  }
+
+  @Override
+  public void writeRawValue(char[] text, int offset, int len) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeRaw(text, offset, len);
+    }
+  }
+
+  @Override
+  public void writeBinary(Base64Variant b64variant, byte[] data, int offset, int len) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeBinary(b64variant, data, offset, len);
+    }
+  }
+
+  @Override
+  public int writeBinary(Base64Variant b64variant, InputStream data, int dataLength) throws IOException {
+    if (itemFilter != null) {
+      return delegate.writeBinary(b64variant, data, dataLength);
+    } else {
+      return -1;
+    }
+  }
+
+    /*
+    /**********************************************************
+    /* Public API, write methods, other value types
+    /**********************************************************
+     */
+
+  @Override
+  public void writeNumber(short v) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeNumber(v);
+    }
+  }
+
+  @Override
+  public void writeNumber(int v) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeNumber(v);
+    }
+  }
+
+  @Override
+  public void writeNumber(long v) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeNumber(v);
+    }
+  }
+
+  @Override
+  public void writeNumber(BigInteger v) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeNumber(v);
+    }
+  }
+
+  @Override
+  public void writeNumber(double v) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeNumber(v);
+    }
+  }
+
+  @Override
+  public void writeNumber(float v) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeNumber(v);
+    }
+  }
+
+  @Override
+  public void writeNumber(BigDecimal v) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeNumber(v);
+    }
+  }
+
+  @Override
+  public void writeNumber(String encodedValue) throws IOException, UnsupportedOperationException {
+    if (itemFilter != null) {
+      delegate.writeNumber(encodedValue);
+    }
+  }
+
+  @Override
+  public void writeBoolean(boolean v) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeBoolean(v);
+    }
+  }
+
+  @Override
+  public void writeNull() throws IOException {
+    if (itemFilter != null) {
+      delegate.writeNull();
+    }
+  }
+
+    /*
+    /**********************************************************
+    /* Overridden field methods
+    /**********************************************************
+     */
+
+  @Override
+  public void writeOmittedField(String fieldName) throws IOException {
+    // Hmmh. Not sure how this would work but...
+    if (itemFilter != null) {
+      delegate.writeOmittedField(fieldName);
+    }
+  }
+
+    /*
+    /**********************************************************
+    /* Public API, write methods, Native Ids
+    /**********************************************************
+     */
+
+  // 25-Mar-2015, tatu: These are tricky as they sort of predate actual filtering calls.
+  //   Let's try to use current state as a clue at least...
+
+  @Override
+  public void writeObjectId(Object id) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeObjectId(id);
+    }
+  }
+
+  @Override
+  public void writeObjectRef(Object id) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeObjectRef(id);
+    }
+  }
+
+  @Override
+  public void writeTypeId(Object id) throws IOException {
+    if (itemFilter != null) {
+      delegate.writeTypeId(id);
+    }
+  }
+}

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringJsonGenerator.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringJsonGenerator.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.core.filter.TokenFilter;
 import com.fasterxml.jackson.core.util.JsonGeneratorDelegate;
 
 /**
- * Subclass of FilteringGeneratorDelegate that forces it to write empty objects and arrays
+ * Clone of FilteringGeneratorDelegate that forces it to write empty objects and arrays
  */
 public class PropertyFilteringJsonGenerator extends JsonGeneratorDelegate {
   private TokenFilter itemFilter;

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringTokenContext.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringTokenContext.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.core.filter.TokenFilter;
 
 /**
- * Subclass of TokenFilterContext that forces it to write empty objects and arrays
+ * Clone of TokenFilterContext that forces it to write empty objects and arrays
  */
 public class PropertyFilteringTokenContext extends JsonStreamContext {
 

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringTokenContext.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilteringTokenContext.java
@@ -1,0 +1,205 @@
+package com.hubspot.jackson.jaxrs;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonStreamContext;
+import com.fasterxml.jackson.core.filter.TokenFilter;
+
+/**
+ * Subclass of TokenFilterContext that forces it to write empty objects and arrays
+ */
+public class PropertyFilteringTokenContext extends JsonStreamContext {
+
+  /**
+   * Parent context for this context; null for root context.
+   */
+  private final PropertyFilteringTokenContext _parent;
+
+    /*
+    /**********************************************************
+    /* Simple instance reuse slots; speed up things
+    /* a bit (10-15%) for docs with lots of small
+    /* arrays/objects
+    /**********************************************************
+     */
+
+  protected PropertyFilteringTokenContext _child;
+
+    /*
+    /**********************************************************
+    /* Location/state information
+    /**********************************************************
+     */
+
+  /**
+   * Name of the field of which value is to be parsed; only
+   * used for OBJECT contexts
+   */
+  protected String _currentName;
+
+  /**
+   * Filter to use for items in this state (for properties of Objects,
+   * elements of Arrays, and root-level values of root context)
+   */
+  protected TokenFilter _filter;
+
+  /**
+   * Flag that indicates that start token has been read/written,
+   * so that matching close token needs to be read/written as well
+   * when context is getting closed.
+   */
+  protected boolean _startHandled;
+
+    /*
+    /**********************************************************
+    /* Life-cycle
+    /**********************************************************
+     */
+
+  protected PropertyFilteringTokenContext(int type, PropertyFilteringTokenContext parent, TokenFilter filter, boolean startHandled) {
+    super();
+    _type = type;
+    _parent = parent;
+    _filter = filter;
+    _index = -1;
+    _startHandled = startHandled;
+  }
+
+  protected PropertyFilteringTokenContext reset(int type, TokenFilter filter, boolean startWritten) {
+    _type = type;
+    _filter = filter;
+    _index = -1;
+    _currentName = null;
+    _startHandled = startWritten;
+    return this;
+  }
+
+    /*
+    /**********************************************************
+    /* Factory methods
+    /**********************************************************
+     */
+
+  public static PropertyFilteringTokenContext createRootContext(TokenFilter filter) {
+    // true -> since we have no start/end marker, consider start handled
+    return new PropertyFilteringTokenContext(TYPE_ROOT, null, filter, true);
+  }
+
+  public PropertyFilteringTokenContext createChildArrayContext(TokenFilter filter, boolean writeStart) {
+    PropertyFilteringTokenContext ctxt = _child;
+    if (ctxt == null) {
+      _child = ctxt = new PropertyFilteringTokenContext(TYPE_ARRAY, this, filter, writeStart);
+      return ctxt;
+    }
+    return ctxt.reset(TYPE_ARRAY, filter, writeStart);
+  }
+
+  public PropertyFilteringTokenContext createChildObjectContext(TokenFilter filter, boolean writeStart) {
+    PropertyFilteringTokenContext ctxt = _child;
+    if (ctxt == null) {
+      _child = ctxt = new PropertyFilteringTokenContext(TYPE_OBJECT, this, filter, writeStart);
+      return ctxt;
+    }
+    return ctxt.reset(TYPE_OBJECT, filter, writeStart);
+  }
+
+    /*
+    /**********************************************************
+    /* State changes
+    /**********************************************************
+     */
+
+  public TokenFilter setFieldName(String name) {
+    _currentName = name;
+    return _filter;
+  }
+
+  public PropertyFilteringTokenContext closeArray(JsonGenerator gen) throws IOException {
+    if (_startHandled) {
+      gen.writeEndArray();
+    }
+    return _parent;
+  }
+
+  public PropertyFilteringTokenContext closeObject(JsonGenerator gen) throws IOException {
+    if (_startHandled) {
+      gen.writeEndObject();
+    }
+    return _parent;
+  }
+
+    /*
+    /**********************************************************
+    /* Accessors, mutators
+    /**********************************************************
+     */
+
+  @Override
+  public Object getCurrentValue() {
+    return null;
+  }
+
+  @Override
+  public void setCurrentValue(Object v) {}
+
+  @Override
+  public final PropertyFilteringTokenContext getParent() {
+    return _parent;
+  }
+
+  @Override
+  public final String getCurrentName() {
+    return _currentName;
+  }
+
+  // @since 2.9
+  @Override
+  public boolean hasCurrentName() {
+    return _currentName != null;
+  }
+
+  public TokenFilter getFilter() {
+    return _filter;
+  }
+
+  // // // Internally used abstract methods
+
+  protected void appendDesc(StringBuilder sb) {
+    if (_parent != null) {
+      _parent.appendDesc(sb);
+    }
+    if (_type == TYPE_OBJECT) {
+      sb.append('{');
+      if (_currentName != null) {
+        sb.append('"');
+        // !!! TODO: Name chars should be escaped?
+        sb.append(_currentName);
+        sb.append('"');
+      } else {
+        sb.append('?');
+      }
+      sb.append('}');
+    } else if (_type == TYPE_ARRAY) {
+      sb.append('[');
+      sb.append(getCurrentIndex());
+      sb.append(']');
+    } else {
+      // nah, ROOT:
+      sb.append("/");
+    }
+  }
+
+  // // // Overridden standard methods
+
+  /**
+   * Overridden to provide developer writeable "JsonPath" representation
+   * of the context.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder(64);
+    appendDesc(sb);
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
Currently, property filtering is implemented by writing the Java objects to a Jackson `TokenBuffer`, parsing this `TokenBuffer` as a `JsonNode`, filtering this `JsonNode` based on the requested properties, and then writing the filtered `JsonNode` to the output stream. This requires buffering the whole JSON structure in memory, which adds a lot of overhead compared to having Jackson just serialize the Java objects directly to the output stream (which is what happens without property filtering). This PR makes it so that filtering happens in a streaming fashion as JSON tokens are being written. So before writing a field name, we check whether this field should be included. If not, we skip writing the field name and its value. 

I wrote up a benchmark using the pathological case of a big JSON blob filtered down to a few fields. The tl;dr is that in this extreme case, the streaming approach is 5x faster (2.8ms vs. 13ms) and does 2 orders of magnitude fewer allocations (64KB vs. >6MB). In fact, the streaming approach adds no allocation overhead compared to the baseline case with no property filtering, and  actually results in a 3.3x speedup over the baseline (2.8ms vs. 9.4ms).

Abridged results available here: https://gist.github.com/jhaber/1002f96293e787f503a3f6734e780ee8

Full benchmark code and results available at: cc6c535a6b80f094d5ed1fb418706e648e883de5