### PR TITLE
upgrade basepom, apply prettier formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>56.1</version>
+    <version>59.2</version>
   </parent>
 
   <groupId>com.hubspot.jackson</groupId>
@@ -16,8 +16,6 @@
   <properties>
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
 
-    <dep.jackson.version>2.12.6</dep.jackson.version>
-    <dep.jackson-databind.version>2.12.6</dep.jackson-databind.version>
     <dep.jaxb.version>2.3.2</dep.jaxb.version>
   </properties>
 

--- a/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
+++ b/src/main/java/com/hubspot/jackson/jaxrs/PropertyFilter.java
@@ -69,7 +69,8 @@ public class PropertyFilter extends TokenFilter {
 
     private final Set<String> includedProperties = new HashSet<String>();
     private final Set<String> excludedProperties = new HashSet<String>();
-    private final Map<String, NestedPropertyFilter> nestedProperties = new HashMap<String, NestedPropertyFilter>();
+    private final Map<String, NestedPropertyFilter> nestedProperties =
+      new HashMap<String, NestedPropertyFilter>();
 
     public void addProperty(String property) {
       boolean excluded = property.startsWith("!");

--- a/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/AbstractIntegrationTest.java
@@ -10,7 +10,8 @@ import org.junit.Test;
 
 public abstract class AbstractIntegrationTest extends BaseTest {
 
-  private static final TypeReference<List<TestObject>> LIST_TYPE = new TypeReference<List<TestObject>>() {};
+  private static final TypeReference<List<TestObject>> LIST_TYPE =
+    new TypeReference<List<TestObject>>() {};
 
   @Test
   public void testNoFiltering() throws IOException {

--- a/src/test/java/com/hubspot/jackson/jaxrs/ArrayIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/ArrayIntegrationTest.java
@@ -12,9 +12,12 @@ import org.junit.Test;
 
 public class ArrayIntegrationTest extends BaseTest {
 
-  private static final TypeReference<List<TestArrayObject>> LIST_ARRAY_TYPE = new TypeReference<List<TestArrayObject>>() {};
-  private static final TypeReference<Map<Long, TestArrayObject>> MAP_ARRAY_TYPE = new TypeReference<Map<Long, TestArrayObject>>() {};
-  private static final TypeReference<TestArrayObject> ARRAY_OBJECT_TYPE = new TypeReference<TestArrayObject>() {};
+  private static final TypeReference<List<TestArrayObject>> LIST_ARRAY_TYPE =
+    new TypeReference<List<TestArrayObject>>() {};
+  private static final TypeReference<Map<Long, TestArrayObject>> MAP_ARRAY_TYPE =
+    new TypeReference<Map<Long, TestArrayObject>>() {};
+  private static final TypeReference<TestArrayObject> ARRAY_OBJECT_TYPE =
+    new TypeReference<TestArrayObject>() {};
 
   @Test
   public void testArrayList() throws IOException {

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedListIntegrationTest.java
@@ -10,7 +10,8 @@ import org.junit.Test;
 
 public class NestedListIntegrationTest extends BaseTest {
 
-  private static final TypeReference<List<TestNestedObject>> LIST_NESTED_TYPE = new TypeReference<List<TestNestedObject>>() {};
+  private static final TypeReference<List<TestNestedObject>> LIST_NESTED_TYPE =
+    new TypeReference<List<TestNestedObject>>() {};
 
   @Test
   public void testNestedObject() throws IOException {

--- a/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
+++ b/src/test/java/com/hubspot/jackson/jaxrs/NestedObjectIntegrationTest.java
@@ -10,8 +10,10 @@ import org.junit.Test;
 
 public class NestedObjectIntegrationTest extends BaseTest {
 
-  private static final TypeReference<Map<Long, TestNestedObject>> MAP_NESTED_TYPE = new TypeReference<Map<Long, TestNestedObject>>() {};
-  private static final TypeReference<TestNestedObject> NESTED_OBJECT_TYPE = new TypeReference<TestNestedObject>() {};
+  private static final TypeReference<Map<Long, TestNestedObject>> MAP_NESTED_TYPE =
+    new TypeReference<Map<Long, TestNestedObject>>() {};
+  private static final TypeReference<TestNestedObject> NESTED_OBJECT_TYPE =
+    new TypeReference<TestNestedObject>() {};
 
   @Test
   public void testNestedObject() throws IOException {


### PR DESCRIPTION
This PR upgrades basepom version to 59, which includes some prettier formatting changes and dependency upgrades.

This will also change the target JDK from 8 to 11; I will publish a release of 0.8.7 prior to merging this in, and apply this PR to the 0.8.8-SNAPSHOT version.